### PR TITLE
Add RabbitMQ extension method overloading for backward compatibility

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
+++ b/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.3</VersionPrefix>
+    <VersionPrefix>3.0.4</VersionPrefix>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Serilog.Sinks.RabbitMQ</AssemblyName>


### PR DESCRIPTION
With the current extension methods it was not possible to overrule the TextFormatter.
To solve this new extension methods are added to be backward compatible with old configuration settings as was in 2.0.2. Also, the existing extension method was changed to allow for a TextFormatter parameter.