### PR TITLE
Support RabbitMQ.Client 6.0

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
+++ b/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.6</VersionPrefix>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <VersionPrefix>4.0.0</VersionPrefix>
+    <TargetFrameworks>net462;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Serilog.Sinks.RabbitMQ</AssemblyName>
     <PackageId>Serilog.Sinks.RabbitMQ</PackageId>
@@ -19,10 +19,11 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
   </ItemGroup>

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -93,12 +93,11 @@ namespace Serilog.Sinks.RabbitMQ
             }
             // setup heartbeat if needed
             if (_config.Heartbeat > 0)
-                connectionFactory.RequestedHeartbeat = _config.Heartbeat;
+                connectionFactory.RequestedHeartbeat = TimeSpan.FromMilliseconds(_config.Heartbeat);
 
             // only set, if has value, otherwise leave default
             if (_config.Port > 0) connectionFactory.Port = _config.Port;
             if (!string.IsNullOrEmpty(_config.VHost)) connectionFactory.VirtualHost = _config.VHost;
-            if (_config.Protocol != null) connectionFactory.Protocol = _config.Protocol;
 
             // return factory
             return connectionFactory;

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTest.cs
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.RabbitMQ.Tests.Integration
                     await Task.Delay(50);
                 });
 
-            var receivedMessage = Encoding.UTF8.GetString(eventRaised.Arguments.Body);
+            var receivedMessage = Encoding.UTF8.GetString(eventRaised.Arguments.Body.ToArray());
             Assert.Equal(message, receivedMessage);
         }
 

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqSinkTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqSinkTest.cs
@@ -61,7 +61,7 @@ namespace Serilog.Sinks.RabbitMQ.Tests.Integration
                     await Task.Delay(50);
                 });
 
-            var receivedMessage = JObject.Parse(Encoding.UTF8.GetString(eventRaised.Arguments.Body));
+            var receivedMessage = JObject.Parse(Encoding.UTF8.GetString(eventRaised.Arguments.Body.ToArray()));
             Assert.Equal("Error", receivedMessage["Level"]);
             Assert.Equal(messageTemplate, receivedMessage["MessageTemplate"]);
             Assert.NotNull(receivedMessage["Properties"]);


### PR DESCRIPTION
Support for RabbitMQ.Client v6.x #102

- note: added support for netcoreaapp2.0, which saves dependencies for those who only need .net core
- note: the Protocol configuration option is now ignored

I just noticed a previous PR that was already being reviewed, so maybe this is not needed, but that older PR references a pre-release version of RabbitMQ while the final version is out already, which I've referenced here. 